### PR TITLE
Add admin security settings panel

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -108,3 +108,4 @@ add_action( 'wp_enqueue_scripts', 'dadecore_theme_scripts' );
 // Incluir módulos adicionales
 require get_template_directory() . '/inc/customizer.php';
 require get_template_directory() . '/inc/security.php';
+require get_template_directory() . '/inc/security-settings.php';

--- a/inc/security-settings.php
+++ b/inc/security-settings.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Seguridad Login settings for DadeCore Theme.
+ */
+
+// Register settings and add menu page.
+function dadecore_security_settings_init() {
+    // Register settings
+    register_setting( 'dadecore_security_settings', 'dadecore_login_slug', array(
+        'sanitize_callback' => 'sanitize_title_with_dashes',
+        'default'           => 'login',
+    ) );
+    register_setting( 'dadecore_security_settings', 'dadecore_max_login_attempts', array(
+        'sanitize_callback' => 'absint',
+        'default'           => 5,
+    ) );
+    register_setting( 'dadecore_security_settings', 'dadecore_login_lockout_minutes', array(
+        'sanitize_callback' => 'absint',
+        'default'           => 15,
+    ) );
+
+    add_options_page(
+        __( 'Seguridad Login', 'dadecore-theme' ),
+        __( 'Seguridad Login', 'dadecore-theme' ),
+        'manage_options',
+        'dadecore-security-settings',
+        'dadecore_security_settings_page'
+    );
+}
+add_action( 'admin_menu', 'dadecore_security_settings_init' );
+
+// Flush rewrite rules if login slug changes.
+function dadecore_flush_rewrite_rules( $old_value, $value, $option ) {
+    if ( $old_value !== $value ) {
+        flush_rewrite_rules();
+    }
+}
+add_action( 'update_option_dadecore_login_slug', 'dadecore_flush_rewrite_rules', 10, 3 );
+
+// Render settings page.
+function dadecore_security_settings_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Seguridad Login', 'dadecore-theme' ); ?></h1>
+        <form method="post" action="options.php">
+            <?php
+            settings_fields( 'dadecore_security_settings' );
+            ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><label for="dadecore_login_slug"><?php esc_html_e( 'Slug personalizado para login', 'dadecore-theme' ); ?></label></th>
+                    <td><input name="dadecore_login_slug" type="text" id="dadecore_login_slug" value="<?php echo esc_attr( get_option( 'dadecore_login_slug', 'login' ) ); ?>" class="regular-text" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="dadecore_max_login_attempts"><?php esc_html_e( 'Máx. intentos fallidos', 'dadecore-theme' ); ?></label></th>
+                    <td><input name="dadecore_max_login_attempts" type="number" id="dadecore_max_login_attempts" value="<?php echo esc_attr( get_option( 'dadecore_max_login_attempts', 5 ) ); ?>" class="small-text" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="dadecore_login_lockout_minutes"><?php esc_html_e( 'Tiempo de bloqueo (minutos)', 'dadecore-theme' ); ?></label></th>
+                    <td><input name="dadecore_login_lockout_minutes" type="number" id="dadecore_login_lockout_minutes" value="<?php echo esc_attr( get_option( 'dadecore_login_lockout_minutes', 15 ) ); ?>" class="small-text" /></td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <?php
+}

--- a/inc/security.php
+++ b/inc/security.php
@@ -3,9 +3,9 @@
  * Basic security enhancements for DadeCore Theme.
  */
 
-// Custom login slug functionality
+// Custom login slug functionality based on option value
 function dadecore_custom_login_slug() {
-    $slug = get_theme_mod( 'login_slug', 'login' );
+    $slug = get_option( 'dadecore_login_slug', 'login' );
     if ( 'login' !== $slug ) {
         add_rewrite_rule( "^{$slug}/?", 'wp-login.php', 'top' );
     }
@@ -17,10 +17,15 @@ function dadecore_limit_login_attempts( $user, $username, $password ) {
     $ip = $_SERVER['REMOTE_ADDR'];
     $key = 'dadecore_login_' . md5( $ip );
     $attempts = (int) get_transient( $key );
-    if ( $attempts >= 5 ) {
+
+    $max_attempts    = (int) get_option( 'dadecore_max_login_attempts', 5 );
+    $lockout_minutes = (int) get_option( 'dadecore_login_lockout_minutes', 15 );
+
+    if ( $attempts >= $max_attempts ) {
         wp_die( __( 'Too many login attempts. Try again later.', 'dadecore-theme' ) );
     }
-    set_transient( $key, $attempts + 1, 15 * MINUTE_IN_SECONDS );
+
+    set_transient( $key, $attempts + 1, $lockout_minutes * MINUTE_IN_SECONDS );
     return $user;
 }
 add_filter( 'authenticate', 'dadecore_limit_login_attempts', 30, 3 );


### PR DESCRIPTION
## Summary
- add new admin page for login security options
- retrieve login slug and rate limit from options in security module
- include new security settings file from `functions.php`

## Testing
- `php -l inc/security-settings.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68632cb103b0832fb378da8c7447c798