### PR TITLE
Add integrations options and improve login security

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -109,3 +109,4 @@ add_action( 'wp_enqueue_scripts', 'dadecore_theme_scripts' );
 require get_template_directory() . '/inc/customizer.php';
 require get_template_directory() . '/inc/security.php';
 require get_template_directory() . '/inc/security-settings.php';
+require get_template_directory() . '/inc/integrations.php';

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -39,3 +39,13 @@ function dadecore_customizer_css() {
     echo '<style type="text/css">:root{--color-green-tech:' . esc_attr( $accent ) . ';}</style>';
 }
 add_action( 'wp_head', 'dadecore_customizer_css' );
+
+// Sync login slug from Customizer to option on save
+function dadecore_customizer_save_login_slug( $manager ) {
+    $slug = $manager->get_setting( 'login_slug' )->value();
+    if ( $slug ) {
+        update_option( 'dadecore_login_slug', sanitize_title_with_dashes( $slug ) );
+        flush_rewrite_rules();
+    }
+}
+add_action( 'customize_save_after', 'dadecore_customizer_save_login_slug' );

--- a/inc/integrations.php
+++ b/inc/integrations.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Integrations settings for DadeCore Theme.
+ */
+
+// Register settings and add menu page
+function dadecore_integrations_settings_init() {
+    register_setting( 'dadecore_integrations', 'dadecore_gtm_head', array(
+        'sanitize_callback' => 'wp_kses_post',
+        'default'           => '',
+    ) );
+    register_setting( 'dadecore_integrations', 'dadecore_gtm_body', array(
+        'sanitize_callback' => 'wp_kses_post',
+        'default'           => '',
+    ) );
+
+    add_options_page(
+        __( 'Integraciones', 'dadecore-theme' ),
+        __( 'Integraciones', 'dadecore-theme' ),
+        'manage_options',
+        'dadecore-integrations',
+        'dadecore_integrations_settings_page'
+    );
+}
+add_action( 'admin_menu', 'dadecore_integrations_settings_init' );
+
+// Render settings page
+function dadecore_integrations_settings_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Integraciones', 'dadecore-theme' ); ?></h1>
+        <form method="post" action="options.php">
+            <?php settings_fields( 'dadecore_integrations' ); ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row"><label for="dadecore_gtm_head"><?php esc_html_e( 'Google Tag Manager &lt;head&gt; code', 'dadecore-theme' ); ?></label></th>
+                    <td>
+                        <textarea name="dadecore_gtm_head" id="dadecore_gtm_head" class="large-text" rows="4"><?php echo esc_textarea( get_option( 'dadecore_gtm_head', '' ) ); ?></textarea>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="dadecore_gtm_body"><?php esc_html_e( 'Google Tag Manager &lt;body&gt; code', 'dadecore-theme' ); ?></label></th>
+                    <td>
+                        <textarea name="dadecore_gtm_body" id="dadecore_gtm_body" class="large-text" rows="4"><?php echo esc_textarea( get_option( 'dadecore_gtm_body', '' ) ); ?></textarea>
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <?php
+}
+
+// Output GTM codes
+function dadecore_output_gtm_head() {
+    $code = get_option( 'dadecore_gtm_head', '' );
+    if ( $code ) {
+        echo $code . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+}
+add_action( 'wp_head', 'dadecore_output_gtm_head' );
+
+function dadecore_output_gtm_body() {
+    $code = get_option( 'dadecore_gtm_body', '' );
+    if ( $code ) {
+        echo $code . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+}
+add_action( 'wp_body_open', 'dadecore_output_gtm_body' );

--- a/inc/security-settings.php
+++ b/inc/security-settings.php
@@ -18,6 +18,14 @@ function dadecore_security_settings_init() {
         'sanitize_callback' => 'absint',
         'default'           => 15,
     ) );
+    register_setting( 'dadecore_security_settings', 'dadecore_hide_default_login', array(
+        'sanitize_callback' => 'absint',
+        'default'           => 1,
+    ) );
+    register_setting( 'dadecore_security_settings', 'dadecore_protect_admin', array(
+        'sanitize_callback' => 'absint',
+        'default'           => 1,
+    ) );
 
     add_options_page(
         __( 'Seguridad Login', 'dadecore-theme' ),
@@ -36,6 +44,7 @@ function dadecore_flush_rewrite_rules( $old_value, $value, $option ) {
     }
 }
 add_action( 'update_option_dadecore_login_slug', 'dadecore_flush_rewrite_rules', 10, 3 );
+add_action( 'update_option_login_slug', 'dadecore_flush_rewrite_rules', 10, 3 );
 
 // Render settings page.
 function dadecore_security_settings_page() {
@@ -58,6 +67,14 @@ function dadecore_security_settings_page() {
                 <tr>
                     <th scope="row"><label for="dadecore_login_lockout_minutes"><?php esc_html_e( 'Tiempo de bloqueo (minutos)', 'dadecore-theme' ); ?></label></th>
                     <td><input name="dadecore_login_lockout_minutes" type="number" id="dadecore_login_lockout_minutes" value="<?php echo esc_attr( get_option( 'dadecore_login_lockout_minutes', 15 ) ); ?>" class="small-text" /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="dadecore_hide_default_login"><?php esc_html_e( 'Ocultar wp-login.php', 'dadecore-theme' ); ?></label></th>
+                    <td><input name="dadecore_hide_default_login" type="checkbox" id="dadecore_hide_default_login" value="1" <?php checked( get_option( 'dadecore_hide_default_login', 1 ) ); ?> /></td>
+                </tr>
+                <tr>
+                    <th scope="row"><label for="dadecore_protect_admin"><?php esc_html_e( 'Proteger wp-admin', 'dadecore-theme' ); ?></label></th>
+                    <td><input name="dadecore_protect_admin" type="checkbox" id="dadecore_protect_admin" value="1" <?php checked( get_option( 'dadecore_protect_admin', 1 ) ); ?> /></td>
                 </tr>
             </table>
             <?php submit_button(); ?>

--- a/inc/security.php
+++ b/inc/security.php
@@ -3,14 +3,51 @@
  * Basic security enhancements for DadeCore Theme.
  */
 
-// Custom login slug functionality based on option value
+// Custom login slug functionality based on option value or Customizer setting
 function dadecore_custom_login_slug() {
-    $slug = get_option( 'dadecore_login_slug', 'login' );
+    $slug = get_option( 'dadecore_login_slug', '' );
+    if ( ! $slug ) {
+        $slug = get_theme_mod( 'login_slug', 'login' );
+    }
     if ( 'login' !== $slug ) {
         add_rewrite_rule( "^{$slug}/?", 'wp-login.php', 'top' );
     }
 }
 add_action( 'init', 'dadecore_custom_login_slug' );
+
+// Keep option and Customizer in sync
+function dadecore_sync_login_slug( $value ) {
+    update_option( 'dadecore_login_slug', sanitize_title_with_dashes( $value ) );
+    return $value;
+}
+add_filter( 'pre_update_option_login_slug', 'dadecore_sync_login_slug' );
+
+// Redirect from default login page if hidden
+function dadecore_redirect_default_login() {
+    $slug           = get_option( 'dadecore_login_slug', 'login' );
+    $hide_default   = (int) get_option( 'dadecore_hide_default_login', 1 );
+    if ( $hide_default && 'login' !== $slug && 'wp-login.php' === basename( $_SERVER['PHP_SELF'] ) ) {
+        wp_redirect( site_url( $slug ) );
+        exit;
+    }
+}
+add_action( 'login_init', 'dadecore_redirect_default_login' );
+
+// Protect wp-admin
+function dadecore_protect_admin_area() {
+    if ( is_user_logged_in() ) {
+        return;
+    }
+
+    $protect_admin = (int) get_option( 'dadecore_protect_admin', 1 );
+    $slug          = get_option( 'dadecore_login_slug', 'login' );
+
+    if ( $protect_admin && strpos( $_SERVER['REQUEST_URI'], 'wp-admin' ) !== false ) {
+        wp_redirect( site_url( $slug ) );
+        exit;
+    }
+}
+add_action( 'init', 'dadecore_protect_admin_area' );
 
 // Limit login attempts using transients
 function dadecore_limit_login_attempts( $user, $username, $password ) {


### PR DESCRIPTION
## Summary
- integrate Google Tag Manager code via new admin page
- include integration loader in theme functions
- sync login slug from the Customizer to security options
- add options to hide default login URLs and protect wp-admin
- redirect wp-login.php when hidden and block wp-admin for visitors

## Testing
- `php -l functions.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68633e8b3164832f8910021a1a3e64f0