### PR TITLE
Fix duplicate custom login slug

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -20,17 +20,6 @@ function dadecore_customize_register( $wp_customize ) {
         )
     ) );
 
-    // Login slug setting for security feature
-    $wp_customize->add_setting( 'login_slug', array(
-        'default' => 'login',
-        'sanitize_callback' => 'sanitize_title_with_dashes',
-    ) );
-
-    $wp_customize->add_control( 'login_slug', array(
-        'label'   => __( 'Custom Login URL Slug', 'dadecore-theme' ),
-        'section' => 'title_tagline',
-        'type'    => 'text',
-    ) );
 }
 add_action( 'customize_register', 'dadecore_customize_register' );
 
@@ -39,13 +28,3 @@ function dadecore_customizer_css() {
     echo '<style type="text/css">:root{--color-green-tech:' . esc_attr( $accent ) . ';}</style>';
 }
 add_action( 'wp_head', 'dadecore_customizer_css' );
-
-// Sync login slug from Customizer to option on save
-function dadecore_customizer_save_login_slug( $manager ) {
-    $slug = $manager->get_setting( 'login_slug' )->value();
-    if ( $slug ) {
-        update_option( 'dadecore_login_slug', sanitize_title_with_dashes( $slug ) );
-        flush_rewrite_rules();
-    }
-}
-add_action( 'customize_save_after', 'dadecore_customizer_save_login_slug' );

--- a/inc/security-settings.php
+++ b/inc/security-settings.php
@@ -44,7 +44,6 @@ function dadecore_flush_rewrite_rules( $old_value, $value, $option ) {
     }
 }
 add_action( 'update_option_dadecore_login_slug', 'dadecore_flush_rewrite_rules', 10, 3 );
-add_action( 'update_option_login_slug', 'dadecore_flush_rewrite_rules', 10, 3 );
 
 // Render settings page.
 function dadecore_security_settings_page() {

--- a/inc/security.php
+++ b/inc/security.php
@@ -3,24 +3,14 @@
  * Basic security enhancements for DadeCore Theme.
  */
 
-// Custom login slug functionality based on option value or Customizer setting
+// Custom login slug functionality based on option value
 function dadecore_custom_login_slug() {
-    $slug = get_option( 'dadecore_login_slug', '' );
-    if ( ! $slug ) {
-        $slug = get_theme_mod( 'login_slug', 'login' );
-    }
+    $slug = get_option( 'dadecore_login_slug', 'login' );
     if ( 'login' !== $slug ) {
         add_rewrite_rule( "^{$slug}/?", 'wp-login.php', 'top' );
     }
 }
 add_action( 'init', 'dadecore_custom_login_slug' );
-
-// Keep option and Customizer in sync
-function dadecore_sync_login_slug( $value ) {
-    update_option( 'dadecore_login_slug', sanitize_title_with_dashes( $value ) );
-    return $value;
-}
-add_filter( 'pre_update_option_login_slug', 'dadecore_sync_login_slug' );
 
 // Redirect from default login page if hidden
 function dadecore_redirect_default_login() {


### PR DESCRIPTION
## Summary
- remove login slug controls from the theme customizer
- simplify security logic to read slug from one option
- stop syncing the old customizer slug value

## Testing
- `php -l inc/customizer.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6863460efbe0832f823ebe0cef730b93