### PR TITLE
Move accent color to palette

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -7,7 +7,6 @@
 /* --- Variables CSS (Colores y Tipografía) --- */
 :root {
     --color-dark-blue: #0A1128;
-    --color-green-tech: #00FFC2; /* Un verde vibrante para tech */
     --color-gray-light: #F0F2F5;
     --color-gray-medium: #A0A0A0;
     --color-gray-dark: #333333;
@@ -51,7 +50,7 @@ body {
 }
 
 a {
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
     text-decoration: none;
     transition: color 0.3s ease;
 }
@@ -133,7 +132,7 @@ img {
 }
 
 .btn-primary {
-    background-color: var(--color-green-tech);
+    background-color: var(--wp--preset--color--accent);
     color: var(--color-dark-blue);
 }
 
@@ -145,12 +144,12 @@ img {
 
 .btn-secondary {
     background-color: transparent;
-    color: var(--color-green-tech);
-    border: 2px solid var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
+    border: 2px solid var(--wp--preset--color--accent);
 }
 
 .btn-secondary:hover {
-    background-color: var(--color-green-tech);
+    background-color: var(--wp--preset--color--accent);
     color: var(--color-dark-blue);
     transform: translateY(-2px);
 }
@@ -182,7 +181,7 @@ img {
 }
 
 .site-title a {
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
     text-decoration: none;
     transition: color 0.3s ease;
 }
@@ -237,7 +236,7 @@ img {
     display: none; /* Se oculta en escritorio, se muestra en móvil */
     background: none;
     border: none;
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
     cursor: pointer;
     z-index: 1001; /* Asegura que esté por encima del menú desplegado */
     padding: 10px; /* Añade un poco de padding para un área de clic más grande */
@@ -256,7 +255,7 @@ img {
     display: block;
     width: 100%;
     height: 3px; /* Grosor de cada línea */
-    background: var(--color-green-tech);
+    background: var(--wp--preset--color--accent);
     position: absolute;
     left: 0;
     transition: all 0.3s ease; /* Transición suave para la animación */
@@ -368,7 +367,7 @@ img {
 }
 
 .hero-title .highlight {
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
 }
 
 .hero-subtitle {
@@ -467,7 +466,7 @@ img {
 .portfolio-item h4 {
     font-size: 1.3em;
     margin-bottom: 5px;
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
 }
 
 /* --- Services Section --- */
@@ -480,7 +479,7 @@ img {
 .service-item h3 {
     font-size: 1.8em;
     margin-bottom: 15px;
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
 }
 
 /* --- Portfolio Section --- */
@@ -503,7 +502,7 @@ img {
 }
 
 .blog-post-item .entry-title a {
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
     font-size: 1.5em;
     display: block; /* Para que ocupe todo el ancho */
     margin-bottom: 10px;
@@ -518,7 +517,7 @@ img {
     display: inline-block;
     margin-top: 15px;
     color: var(--color-white);
-    background: var(--color-green-tech);
+    background: var(--wp--preset--color--accent);
     padding: 8px 15px;
     border-radius: 5px;
     transition: background-color 0.3s ease;
@@ -540,7 +539,7 @@ img {
 }
 
 .site-footer a {
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
 }
 
 /* --- Responsive adjustments --- */
@@ -665,7 +664,7 @@ img {
 .single-post-item .entry-title {
     font-size: 2.8em;
     margin-bottom: 10px;
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
     text-align: left; /* Títulos de posts individuales a la izquierda */
 }
 
@@ -719,7 +718,7 @@ img {
 }
 
 .entry-content a {
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
     text-decoration: underline;
 }
 
@@ -736,7 +735,7 @@ img {
 }
 
 .tag-links a {
-    background-color: var(--color-green-tech);
+    background-color: var(--wp--preset--color--accent);
     color: var(--color-dark-blue);
     padding: 5px 10px;
     border-radius: 3px;
@@ -782,7 +781,7 @@ img {
 
 .comment-author {
     font-weight: bold;
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
 }
 
 .comment-metadata {
@@ -797,7 +796,7 @@ img {
 }
 
 .comment-reply-link {
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
     text-decoration: underline;
 }
 
@@ -836,7 +835,7 @@ img {
 
 .comment-form input[type="submit"] {
     /* Corregido: Reemplazado @extend con los estilos directos para compatibilidad CSS nativa */
-    background-color: var(--color-green-tech);
+    background-color: var(--wp--preset--color--accent);
     color: var(--color-dark-blue);
     display: inline-block;
     padding: 12px 25px;
@@ -899,22 +898,22 @@ img {
     padding: 8px 15px;
     border: 1px solid var(--glass-border);
     background: var(--glass-background);
-    color: var(--color-green-tech);
+    color: var(--wp--preset--color--accent);
     text-decoration: none;
     border-radius: 5px;
     transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
 .page-numbers.current {
-    background-color: var(--color-green-tech);
+    background-color: var(--wp--preset--color--accent);
     color: var(--color-dark-blue);
-    border-color: var(--color-green-tech);
+    border-color: var(--wp--preset--color--accent);
 }
 
 .page-numbers:hover:not(.current) {
     background-color: rgba(0, 255, 194, 0.1);
     color: var(--color-white);
-    border-color: var(--color-green-tech);
+    border-color: var(--wp--preset--color--accent);
 }
 
 .screen-reader-text {
@@ -967,7 +966,7 @@ img {
 }
 
 .cookie-banner button {
-    background: var(--color-green-tech);
+    background: var(--wp--preset--color--accent);
     color: var(--color-dark-blue);
     border: none;
     padding: 8px 16px;

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -1,30 +1,7 @@
 <?php
 /**
- * Simple Customizer settings for DadeCore Theme.
+ * Theme customizer adjustments.
+ *
+ * The accent color is now defined via theme.json and no longer configurable
+ * through the Customizer.
  */
-
-function dadecore_customize_register( $wp_customize ) {
-    // Accent color setting
-    $wp_customize->add_setting( 'accent_color', array(
-        'default'   => '#00FFC2',
-        'transport' => 'refresh',
-        'sanitize_callback' => 'sanitize_hex_color',
-    ) );
-
-    $wp_customize->add_control( new WP_Customize_Color_Control(
-        $wp_customize,
-        'accent_color',
-        array(
-            'label'    => __( 'Accent Color', 'dadecore-theme' ),
-            'section'  => 'colors',
-        )
-    ) );
-
-}
-add_action( 'customize_register', 'dadecore_customize_register' );
-
-function dadecore_customizer_css() {
-    $accent = get_theme_mod( 'accent_color', '#00FFC2' );
-    echo '<style type="text/css">:root{--color-green-tech:' . esc_attr( $accent ) . ';}</style>';
-}
-add_action( 'wp_head', 'dadecore_customizer_css' );

--- a/theme.json
+++ b/theme.json
@@ -4,7 +4,7 @@
     "color": {
       "palette": [
         {"name": "Dark Blue", "slug": "dark-blue", "color": "#0A1128"},
-        {"name": "Green Tech", "slug": "green-tech", "color": "#00FFC2"},
+        {"name": "Accent", "slug": "accent", "color": "#00FFC2"},
         {"name": "Gray Light", "slug": "gray-light", "color": "#F0F2F5"},
         {"name": "White", "slug": "white", "color": "#FFFFFF"}
       ]


### PR DESCRIPTION
## Summary
- set accent color in `theme.json`
- remove Customizer accent setting
- reference palette accent color in styles

## Testing
- `grep -n "wp--preset--color--accent" -n assets/css/main.css | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68634d98a0f4832fb06b3e035d8c2e7e