### PR TITLE
Add translations directory and load text domain

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,6 +4,7 @@
  */
 
 function dadecore_setup() {
+    load_theme_textdomain( 'dadecore-theme', get_template_directory() . '/languages' );
     add_theme_support( 'wp-block-styles' );
     add_theme_support( 'editor-styles' );
     add_theme_support( 'block-templates' );

--- a/languages/dadecore-theme.pot
+++ b/languages/dadecore-theme.pot
@@ -1,0 +1,59 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-01 03:07+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: inc/integrations.php:18 inc/integrations.php:19 inc/integrations.php:31
+msgid "Integraciones"
+msgstr ""
+
+#: inc/integrations.php:36
+msgid "Google Tag Manager &lt;head&gt; code"
+msgstr ""
+
+#: inc/integrations.php:42
+msgid "Google Tag Manager &lt;body&gt; code"
+msgstr ""
+
+#: inc/security-settings.php:31 inc/security-settings.php:32
+#: inc/security-settings.php:52
+msgid "Seguridad Login"
+msgstr ""
+
+#: inc/security-settings.php:59
+msgid "Slug personalizado para login"
+msgstr ""
+
+#: inc/security-settings.php:63
+msgid "Máx. intentos fallidos"
+msgstr ""
+
+#: inc/security-settings.php:67
+msgid "Tiempo de bloqueo (minutos)"
+msgstr ""
+
+#: inc/security-settings.php:71
+msgid "Ocultar wp-login.php"
+msgstr ""
+
+#: inc/security-settings.php:75
+msgid "Proteger wp-admin"
+msgstr ""
+
+#: inc/security.php:52
+msgid "Too many login attempts. Try again later."
+msgstr ""


### PR DESCRIPTION
## Summary
- add `languages` directory
- generate initial `dadecore-theme.pot`
- load theme text domain from the new folder

## Testing
- `xgettext -L PHP --from-code=UTF-8 -k__ -k_e -kesc_html_e -o languages/dadecore-theme.pot $(git ls-files '*.php')`
- *No tests run due to missing PHP interpreter*

------
https://chatgpt.com/codex/tasks/task_e_6863507592ec832f8c8ecd0edb0439d8