### PR TITLE
Improve script loading

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -16,12 +16,36 @@ add_action( 'after_setup_theme', 'dadecore_setup' );
 /**
  * Enqueue theme assets.
  */
-function dadecore_enqueue_assets() {
-    wp_enqueue_style( 'dadecore-theme', get_template_directory_uri() . '/assets/css/main.css', array(), null );
-    wp_enqueue_style( 'dadecore-fonts', 'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@400;700&display=swap', array(), null );
-    wp_enqueue_script( 'dadecore-script', get_template_directory_uri() . '/assets/js/main.js', array(), null, true );
+function dadecore_theme_scripts() {
+    $theme_version = wp_get_theme()->get( 'Version' );
+
+    if ( ! is_admin() ) {
+        wp_enqueue_style(
+            'dadecore-theme',
+            get_template_directory_uri() . '/assets/css/main.css',
+            array(),
+            $theme_version
+        );
+
+        wp_enqueue_style(
+            'dadecore-fonts',
+            'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@400;700&display=swap',
+            array(),
+            null
+        );
+    }
+
+    if ( ( has_nav_menu( 'primary' ) || ( function_exists( 'has_block' ) && has_block( 'core/navigation' ) ) ) && ! is_admin() ) {
+        wp_enqueue_script(
+            'dadecore-script',
+            get_template_directory_uri() . '/assets/js/main.js',
+            array(),
+            $theme_version,
+            true
+        );
+    }
 }
-add_action( 'wp_enqueue_scripts', 'dadecore_enqueue_assets' );
+add_action( 'wp_enqueue_scripts', 'dadecore_theme_scripts' );
 
 require get_template_directory() . '/inc/customizer.php';
 require get_template_directory() . '/inc/security.php';


### PR DESCRIPTION
## Summary
- load CSS/JS with `dadecore_theme_scripts()`
- only enqueue `main.js` if a navigation block or primary menu exists

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68635215f298832fadf7ff3b2c37662c