### PR TITLE
Add theme setup features and widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# DadeCore Theme
+
+This theme provides a block-first approach for WordPress and includes several convenient features enabled in `functions.php`.
+
+## Theme Setup
+
+The `dadecore_setup()` function loads text domains and enables core WordPress features:
+
+- Block styles and editor styles
+- Block templates and template parts
+- **Title tag support** so WordPress manages the document title
+- **Post thumbnails** for featured images
+- **HTML5 markup** for search forms, comment forms, comment lists, galleries and captions
+- Registers the **Primary Menu** location
+
+## Widgets
+
+`dadecore_widgets_init()` registers two widget areas using `register_sidebar()`:
+
+1. **Blog Sidebar** – displayed on blog templates
+2. **Footer Widgets** – used for footer content
+
+Add widgets to these areas through the WordPress Admin under *Appearance → Widgets*.

--- a/functions.php
+++ b/functions.php
@@ -9,6 +9,17 @@ function dadecore_setup() {
     add_theme_support( 'editor-styles' );
     add_theme_support( 'block-templates' );
     add_theme_support( 'block-template-parts' );
+    add_theme_support( 'title-tag' );
+    add_theme_support( 'post-thumbnails' );
+    add_theme_support(
+        'html5',
+        array( 'search-form', 'comment-form', 'comment-list', 'gallery', 'caption' )
+    );
+    register_nav_menus(
+        array(
+            'primary' => __( 'Primary Menu', 'dadecore-theme' ),
+        )
+    );
     add_editor_style( 'assets/css/main.css' );
 }
 add_action( 'after_setup_theme', 'dadecore_setup' );
@@ -46,6 +57,36 @@ function dadecore_theme_scripts() {
     }
 }
 add_action( 'wp_enqueue_scripts', 'dadecore_theme_scripts' );
+
+/**
+ * Register widget areas.
+ */
+function dadecore_widgets_init() {
+    register_sidebar(
+        array(
+            'name'          => __( 'Blog Sidebar', 'dadecore-theme' ),
+            'id'            => 'sidebar-1',
+            'description'   => __( 'Add widgets here to appear in your blog sidebar.', 'dadecore-theme' ),
+            'before_widget' => '<section id="%1$s" class="widget %2$s">',
+            'after_widget'  => '</section>',
+            'before_title'  => '<h2 class="widget-title">',
+            'after_title'   => '</h2>',
+        )
+    );
+
+    register_sidebar(
+        array(
+            'name'          => __( 'Footer Widgets', 'dadecore-theme' ),
+            'id'            => 'footer-1',
+            'description'   => __( 'Widgets added here will appear in the footer.', 'dadecore-theme' ),
+            'before_widget' => '<section id="%1$s" class="widget %2$s">',
+            'after_widget'  => '</section>',
+            'before_title'  => '<h2 class="widget-title">',
+            'after_title'   => '</h2>',
+        )
+    );
+}
+add_action( 'widgets_init', 'dadecore_widgets_init' );
 
 require get_template_directory() . '/inc/customizer.php';
 require get_template_directory() . '/inc/security.php';


### PR DESCRIPTION
## Summary
- enhance theme initialization with more WP features
- add widget areas for sidebar and footer
- document new functionality in README

## Testing
- `php -l functions.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686532beb070832fa15b9412762e692d